### PR TITLE
fix: change asset page link

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,3 @@
 https://forge.trade https://app.forge.trade/ 301!
-/assets/* https://assets.forge.trade/ 308!
+/assets/* https://assets.evmos.org/ 308!
 /info/* https://info.forge.trade/ 200!

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -66,10 +66,11 @@ export const PageTabs = () => {
       {!isMobile && (
         <>
           <a
-            href="https://assets.forge.trade/"
+            href="https://assets.evmos.org/"
             rel="noopener noreferrer"
             id="pool-nav-link"
             className={styles.menuItem}
+            target="_blank"
           >
             <Trans>Assets</Trans>
           </a>

--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 export default function RedirectAssets() {
   useEffect(() => {
-    window.location.href = 'https://assets.forge.trade'
+    window.location.href = 'https://assets.evmos.org'
   }, [])
 
   return null


### PR DESCRIPTION
The link change that redirects when pressing assets was made.

link: https://assets.forge.trade for the link: https://assets.evmos.org

Objective: adapt to the future changes that the Evmos STR project will bring.
